### PR TITLE
fix(windows): 貼り付け転写の話者分離でwebrtcvadが見つからない問題を修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,16 @@ dev = [
     "pytest",
     "ruff",
 ]
+
+[[tool.uv.dependency-metadata]]
+name = "resemblyzer"
+version = "0.1.4"
+requires-dist = [
+    "numpy",
+    "scipy",
+    "librosa",
+    "scikit-learn",
+    "Unidecode",
+    "inflect",
+    "webrtcvad-wheels",
+]

--- a/start.bat
+++ b/start.bat
@@ -9,6 +9,6 @@ echo Waiting for Ollama...
 timeout /t 4 /nobreak > nul
 
 echo Starting Echonote...
-uv run echonote
+uv run --extra diarization echonote
 
 pause


### PR DESCRIPTION
## 問題

Windowsで `uv run --extra diarization echonote` を実行すると `webrtcvad` のビルドに失敗する。

```
error: Microsoft Visual C++ 14.0 or greater is required.
```

`resemblyzer` が `webrtcvad`（要コンパイル）に依存しており、Visual C++ がない環境でソースビルドが走るため。

## 修正内容

### `start.bat`
`uv run` に `--extra diarization` を追加。起動時に diarization 依存が常に確保されるようにする。

### `pyproject.toml`
`[[tool.uv.dependency-metadata]]` で resemblyzer 0.1.4 の `webrtcvad` 依存を `webrtcvad-wheels`（プリビルド済み）に差し替え。Visual C++ 不要で Windows でもインストール可能になる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBMzjjroiXCnHcd7kXuq4y)_